### PR TITLE
fix version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install:
 ```bash
 cargo install \
   --git https://github.com/timewave-computer/valence-coprocessor.git \
-  --tag v0.4.0 \
+  --tag v0.3.0 \
   --locked cargo-valence
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions in the README to specify version tag v0.3.0 for the cargo-valence CLI helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->